### PR TITLE
Update webcrawl.py

### DIFF
--- a/utils/webcrawl.py
+++ b/utils/webcrawl.py
@@ -131,6 +131,7 @@ async def crawl(url):
             soup = BeautifulSoup(await response.text(), "html.parser")
             for link in soup.find_all("loc"):
                 link = link.text
+                link = link.replace(" ", "")
                 links.append(link)
 
     async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
Some sitemap sites have spaces proceeding and pre-pending the url causing the crawl to fail. Correction solves for this possibility.